### PR TITLE
v1.0.1: Fix bug in which sync only retrieves 96 examples

### DIFF
--- a/app/helpers/sync.js
+++ b/app/helpers/sync.js
@@ -4,12 +4,10 @@ var Repo = require('../models/repo').Repo;
 module.exports = function(excluded, github) {
     var client = github.client;
 
-    var currentPage = 0;
+    var currentPage = 1; // Github's API has a 1-indexed paging system
     var perPage = 100;
     var repoCount = 0;
     var len = 0;
-
-    var promises = [];
     
     function getRepoPage(res) {
         len = res.length;
@@ -58,7 +56,7 @@ module.exports = function(excluded, github) {
                 .then(function() {
                     if (len >= perPage) {
                         currentPage += 1;
-                        promises.push(next());
+                        return next();
                     }
                 })
                 .catch(function (err) {
@@ -66,9 +64,7 @@ module.exports = function(excluded, github) {
                 });
     }
     
-    promises.push(next());
-
-    return Promise.all(promises)
+    return next()
         .then(function() {
             return repoCount;
         });


### PR DESCRIPTION
This commit fixes an issue in which hitting `/sync` only records 96 of the 200+ repos currently available.

The problem is fixed by changing the options to start at `page=1` instead of `page=0`.  See the relevant [documentation](https://developer.github.com/v3/#pagination).

Note that this alone fixes the recording problem, but introduces another problem in which the number of recorded repos is not _reported_ correctly, which is fixed by forcing the relevant code to run sync instead of async.  This is accomplished by removing the promise pattern.
